### PR TITLE
Update fordpass_new.py

### DIFF
--- a/custom_components/fordpass/fordpass_new.py
+++ b/custom_components/fordpass/fordpass_new.py
@@ -10,7 +10,7 @@ import time
 
 from base64 import urlsafe_b64encode, urlsafe_b64decode
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 
 _LOGGER = logging.getLogger(__name__)
 defaultHeaders = {


### PR DESCRIPTION
Use urllib3 for Retry class (requests.packages.urllib3.util.retry - was left for backwards capabilities).