### PR TITLE
Add more sensor data for Diesel

### DIFF
--- a/custom_components/fordpass/const.py
+++ b/custom_components/fordpass/const.py
@@ -52,7 +52,10 @@ SENSORS = {
     "zoneLighting": {"icon": "mdi:spotlight-beam"},
     "messages": {"icon": "mdi:message-text"},
     "dieselSystemStatus": {"icon": "mdi:smoking-pipe"},
-    "exhaustFluidLevel": {"icon": "mdi:barrel"}
+    "filterRegenerationStatus": {"icon": "mdi:smoking-pipe"},
+    "exhaustFluidLevel": {"icon": "mdi:barrel"},
+    "filterSoot": {"icon": "mdi:barrel"},
+    "ureaRange": {"icon": "mdi:barrel"},
 }
 
 SWITCHES = {"ignition": {"icon": "hass:power"}, "guardmode": {"icon": "mdi:shield-key"}}

--- a/custom_components/fordpass/sensor.py
+++ b/custom_components/fordpass/sensor.py
@@ -31,10 +31,19 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             if sensor.coordinator.data["elVehDTE"] != None:
                 sensors.append(sensor)
         elif key == "dieselSystemStatus":
-            if "dieselSystemStatus" in sensor.coordinator.data and sensor.coordinator.data["dieselSystemStatus"]["filterRegenerationStatus"] != None:
+            if sensor.coordinator.data.get("dieselSystemStatus") != None:
+                sensors.append(sensor)
+        elif key == "filterRegenerationStatus":
+            if sensor.coordinator.data.get("dieselSystemStatus", {}).get("filterRegenerationStatus") != None:
                 sensors.append(sensor)
         elif key == "exhaustFluidLevel":
-            if "exhaustFluidLevel" in sensor.coordinator.data and sensor.coordinator.data["dieselSystemStatus"]["exhaustFluidLevel"] != None:
+            if sensor.coordinator.data.get("dieselSystemStatus", {}).get("exhaustFluidLevel") != None:
+                sensors.append(sensor)
+        elif key == "filterSoot":
+            if sensor.coordinator.data.get("dieselSystemStatus", {}).get("filterSoot") != None:
+                sensors.append(sensor)
+        elif key == "ureaRange":
+            if sensor.coordinator.data.get("dieselSystemStatus", {}).get("ureaRange") != None:
                 sensors.append(sensor)
         else:
             sensors.append(sensor)


### PR DESCRIPTION
This commit fixes a bug with detecting exhaustFluid data correctly, adds three more sensors - ureaRange, filterSoot, and filterRegenerationStatus as well as replacing the existing dieselStatus sensor with the full result of the API data instead of just the filter regen.

Expands on this issue https://github.com/itchannel/fordpass-ha/issues/233