### PR TITLE
EV Features and Temp conversions

### DIFF
--- a/custom_components/fordpass/sensor.py
+++ b/custom_components/fordpass/sensor.py
@@ -553,6 +553,27 @@ class CarSensor(
                     attribs["parkingBrakeStatus"] = self.data["parkingBrakeStatus"]["value"]
                 if "torqueAtTransmission" in self.data:
                     attribs["torqueAtTransmission"] = self.data["torqueAtTransmission"]["value"]
+                if "ambientTemp" in self.data:
+                    attribs["ambientTemp"] = self.data["ambientTemp"]["value"]
+                if "tripFuelEconomy" in self.data:
+                    if "xevBatteryVoltage" in self.data:
+                        # Do not display tripFuelEconomy if EV
+                        # tripXevBatteryChargeRegenerated should be a previous FordPass feature called "Driving Score". % based on how much regen vs brake you do
+                        attribs["Driving Score"] = self.data["tripXevBatteryChargeRegenerated"]["value"]
+                        if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
+                            attribs["Range Regenerated"] = round(float(self.data["tripXevBatteryRangeRegenerated"]["value"]) / 1.60934)
+                        else:
+                            attribs["Range Regenerated"] = self.data["tripXevBatteryRangeRegenerated"]["value"]
+                    else:
+                        # Hybrid does not seem to have xevBatteryVoltage, but does have RangeRegen and "Driving Score" keys
+                        if "tripXevBatteryChargeRegenerated" in self.data:
+                            attribs["Driving Score"] = self.data["tripXevBatteryChargeRegenerated"]["value"]
+                            if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
+                                attribs["Range Regenerated"] = round(float(self.data["tripXevBatteryRangeRegenerated"]["value"]) / 1.60934)
+                            else:
+                                attribs["Range Regenerated"] = self.data["tripXevBatteryRangeRegenerated"]["value"]
+                        # ICE vehicles, and Hybrid get tripFuelEconomy
+                        attribs["tripFuelEconomy"] = self.data["tripFuelEconomy"]["value"]
                 return attribs
             if self.sensor == "indicators":
                 alerts = {}

--- a/custom_components/fordpass/sensor.py
+++ b/custom_components/fordpass/sensor.py
@@ -286,9 +286,8 @@ class CarSensor(
                 return self.data[self.sensor].items()
             if self.sensor == "outsideTemp":
                 if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
-                    return round(float(self.data["ambientTemp"]["value"] * 9/5) + 32)
-                return self.data["ambientTemp"]["value"]   
-
+                    return {"Ambient Temp": round(float(self.data["ambientTemp"]["value"] * 9/5) + 32)}
+                return {"Ambient Temp": self.data["ambientTemp"]["value"]}
             if self.sensor == "fuel":
                 if "fuelRange" in self.data:
                     if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
@@ -382,20 +381,6 @@ class CarSensor(
                     return None
                 elecs = {}                    
                 if (
-                    "xevPlugChargerStatus" in self.data and self.data["xevPlugChargerStatus"] is not None and self.data["xevPlugChargerStatus"]["value"] is not None
-                ):
-                    elecs["Plug Status"] = self.data["xevPlugChargerStatus"][
-                        "value"
-                    ]
-
-                if (
-                    "xevBatteryChargeDisplayStatus" in self.data and self.data["xevBatteryChargeDisplayStatus"] is not None and self.data["xevBatteryChargeDisplayStatus"]["value"] is not None
-                ):
-                    elecs["Charging Status"] = self.data[
-                        "xevBatteryChargeDisplayStatus"
-                    ]["value"]
-
-                if (
                     "xevBatteryPerformanceStatus" in self.data and self.data["xevBatteryPerformanceStatus"] is not None and self.data["xevBatteryPerformanceStatus"]["value"] is not None
                 ):
                     elecs["Battery Performance Status"] = self.data[
@@ -416,8 +401,8 @@ class CarSensor(
                         "xevBatteryActualStateOfCharge"
                     ]["value"]
 
+                # tripXevBatteryChargeRegenerated should be a previous FordPass feature called "Driving Score". A % based on how much regen vs brake you use
                 if (
-                    # tripXevBatteryChargeRegenerated should be a previous FordPass feature called "Driving Score". A % based on how much regen vs brake you use
                     "tripXevBatteryChargeRegenerated" in self.data and self.data["tripXevBatteryChargeRegenerated"] is not None and self.data["tripXevBatteryChargeRegenerated"]["value"] is not None
                 ):
                     elecs["Driving Score"] = self.data["tripXevBatteryChargeRegenerated"]["value"]
@@ -439,25 +424,26 @@ class CarSensor(
                     "xevBatteryMaximumRange" in self.data and self.data["xevBatteryMaximumRange"] is not None and self.data["xevBatteryMaximumRange"]["value"] is not None
                 ):
                     if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
-                        elecs["Maximum Battery Range"] = round(
-                                float(self.data["xevBatteryMaximumRange"]["value"]) / 1.60934
-                            )
+                        elecs["Maximum Battery Range"] = round(float(self.data["xevBatteryMaximumRange"]["value"]) / 1.60934)
                     else:
                         elecs["Maximum Battery Range"] = self.data["xevBatteryMaximumRange"]["value"]
+
                 if (
                     "xevBatteryVoltage" in self.data and self.data["xevBatteryVoltage"] is not None and self.data["xevBatteryVoltage"]["value"] is not None
                 ):
                     elecs["Battery Voltage"] = float(self.data["xevBatteryVoltage"]["value"])
-                    battVolt = elecs["Charging Voltage"]
+                    battVolt = elecs["Battery Voltage"]
+
                 if (
                     "xevBatteryIoCurrent" in self.data and self.data["xevBatteryIoCurrent"] is not None and self.data["xevBatteryIoCurrent"]["value"] is not None
                 ):
                     elecs["Battery Amperage"] = float(self.data["xevBatteryIoCurrent"]["value"])
                     battAmps = elecs["Battery Amperage"]
                 if (
-                    self.data["xevBatteryIoCurrent"]["value"] is not None and self.data["xevBatteryVoltage"]["value"] is not None
+                    "xevBatteryIoCurrent" in self.data and self.data["xevBatteryIoCurrent"] is not None and self.data["xevBatteryIoCurrent"]["value"] is not None
                 ):
                     elecs["Battery kW"] =  round((battVolt * battAmps) / 1000, 2)
+                    
                 if (
                     "xevTractionMotorVoltage" in self.data and self.data["xevTractionMotorVoltage"] is not None and self.data["xevTractionMotorVoltage"]["value"] is not None
                 ):
@@ -469,7 +455,7 @@ class CarSensor(
                     elecs["Motor Amperage"] = float(self.data["xevTractionMotorCurrent"]["value"])
                     motorAmps = elecs["Motor Amperage"]
                 if (
-                    self.data["xevTractionMotorCurrent"]["value"] is not None and self.data["xevTractionMotorVoltage"]["value"] is not None
+                    "xevTractionMotorVoltage" in self.data and self.data["xevTractionMotorVoltage"] is not None and self.data["xevTractionMotorVoltage"]["value"] is not None 
                 ):
                     elecs["Motor kW"] =  round((motorVolt * motorAmps) / 1000, 2)
                         
@@ -479,13 +465,18 @@ class CarSensor(
             if self.sensor == "elVehCharging":
                 if "xevPlugChargerStatus" not in self.data:
                     return None
-
                 cs = {}
+
+                if (
+                    "xevPlugChargerStatus" in self.data and self.data["xevPlugChargerStatus"] is not None and self.data["xevPlugChargerStatus"]["value"] is not None
+                ):
+                    cs["Plug Status"] = self.data["xevPlugChargerStatus"]["value"]
 
                 if (
                     "xevBatteryStateOfCharge" in self.data and self.data["xevBatteryStateOfCharge"] is not None and self.data["xevBatteryStateOfCharge"]["value"] is not None
                 ):
                     cs["Charging State of Charge"] = self.data["xevBatteryStateOfCharge"]["value"]
+                    
                 if ("xevBatteryChargeDisplayStatus" in self.data and self.data["xevBatteryChargeDisplayStatus"] is not None and self.data["xevBatteryChargeDisplayStatus"]["value"] is not None
                 ):
                     cs["Charging Status"] = self.data["xevBatteryChargeDisplayStatus"]["value"]
@@ -510,9 +501,9 @@ class CarSensor(
                     "xevBatteryTemperature" in self.data and self.data["xevBatteryTemperature"] is not None and self.data["xevBatteryTemperature"]["value"] is not None
                 ):
                     if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
-                        cs["Battery Temperature"] = round(float(self.data["xevBatteryTemperature"]["value"] * 9/5) + 32)
+                        cs["Battery Temperature °F"] = round(float(self.data["xevBatteryTemperature"]["value"] * 9/5) + 32)
                     else: 
-                        cs["Battery Temperature"] = self.data["xevBatteryTemperature"]["value"]
+                        cs["Battery Temperature °C"] = self.data["xevBatteryTemperature"]["value"]
                 if (
                     "xevBatteryChargerVoltageOutput" in self.data and self.data["xevBatteryChargerVoltageOutput"] is not None and self.data["xevBatteryChargerVoltageOutput"]["value"] is not None
                 ):
@@ -534,6 +525,7 @@ class CarSensor(
                     cs["Time To Full Charge"] = self.data["xevBatteryTimeToFullCharge"]["value"]
 
                 return cs
+            
             if self.sensor == "zoneLighting":
                 if "zoneLighting" not in self.data:
                     return None

--- a/custom_components/fordpass/sensor.py
+++ b/custom_components/fordpass/sensor.py
@@ -384,20 +384,6 @@ class CarSensor(
                     ]["value"]
 
                 if (
-                    "xevChargeStationPowerType" in self.data and self.data["xevChargeStationPowerType"] is not None and self.data["xevChargeStationPowerType"]["value"] is not None
-                ):
-                    elecs["Charger Power Type"] = self.data[
-                        "xevChargeStationPowerType"
-                    ]["value"]
-
-                if (
-                    "xevChargeStationCommunicationStatus" in self.data and self.data["xevChargeStationCommunicationStatus"] is not None and self.data["xevChargeStationCommunicationStatus"]["value"] is not None
-                ):
-                    elecs["Battery Charge Status"] = self.data[
-                        "xevChargeStationCommunicationStatus"
-                    ]["value"]
-
-                if (
                     "xevBatteryPerformanceStatus" in self.data and self.data["xevBatteryPerformanceStatus"] is not None and self.data["xevBatteryPerformanceStatus"]["value"] is not None
                 ):
                     elecs["Battery Performance Status"] = self.data[
@@ -409,6 +395,13 @@ class CarSensor(
                 ):
                     elecs["Battery Charge"] = self.data[
                         "xevBatteryStateOfCharge"
+                    ]["value"]
+
+                if (
+                    "xevBatteryActualStateOfCharge" in self.data and self.data["xevBatteryActualStateOfCharge"] is not None and self.data["xevBatteryActualStateOfCharge"]["value"] is not None
+                ):
+                    elecs["Battery Actual Charge"] = self.data[
+                        "xevBatteryActualStateOfCharge"
                     ]["value"]
 
                 if (
@@ -439,6 +432,35 @@ class CarSensor(
                             )
                     else:
                         elecs["Maximum Battery Range"] = self.data["xevBatteryMaximumRange"]["value"]
+                if (
+                    "xevBatteryVoltage" in self.data and self.data["xevBatteryVoltage"] is not None and self.data["xevBatteryVoltage"]["value"] is not None
+                ):
+                    elecs["Battery Voltage"] = float(self.data["xevBatteryVoltage"]["value"])
+                    battVolt = elecs["Charging Voltage"]
+                if (
+                    "xevBatteryIoCurrent" in self.data and self.data["xevBatteryIoCurrent"] is not None and self.data["xevBatteryIoCurrent"]["value"] is not None
+                ):
+                    elecs["Battery Amperage"] = float(self.data["xevBatteryIoCurrent"]["value"])
+                    battAmps = elecs["Battery Amperage"]
+                if (
+                    self.data["xevBatteryIoCurrent"]["value"] is not None and self.data["xevBatteryVoltage"]["value"] is not None
+                ):
+                    elecs["Battery kW"] =  round((battVolt * battAmps) / 1000, 2)
+                if (
+                    "xevTractionMotorVoltage" in self.data and self.data["xevTractionMotorVoltage"] is not None and self.data["xevTractionMotorVoltage"]["value"] is not None
+                ):
+                    elecs["Motor Voltage"] = float(self.data["xevTractionMotorVoltage"]["value"])
+                    motorVolt = elecs["Motor Voltage"]
+                if (
+                    "xevTractionMotorCurrent" in self.data and self.data["xevTractionMotorCurrent"] is not None and self.data["xevTractionMotorCurrent"]["value"] is not None
+                ):
+                    elecs["Motor Amperage"] = float(self.data["xevTractionMotorCurrent"]["value"])
+                    motorAmps = elecs["Motor Amperage"]
+                if (
+                    self.data["xevTractionMotorCurrent"]["value"] is not None and self.data["xevTractionMotorVoltage"]["value"] is not None
+                ):
+                    elecs["Motor kW"] =  round((motorVolt * motorAmps) / 1000, 2)
+                        
                 return elecs
 
             ## SquidBytes: Added elVehCharging
@@ -464,6 +486,15 @@ class CarSensor(
                 ):
                     cs["Charge Station Status"] = self.data["xevChargeStationCommunicationStatus"]["value"]
                 if (
+                    "tripXevBatteryDistanceAccumulated" in self.data and self.data["tripXevBatteryDistanceAccumulated"] is not None and self.data["tripXevBatteryDistanceAccumulated"]["value"] is not None
+                ):
+                    if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
+                        cs["Distance Accumulated"] = round(
+                                float(self.data["tripXevBatteryDistanceAccumulated"]["value"]) / 1.60934
+                            )
+                    else:
+                        cs["Distance Accumulated"] = self.data["tripXevBatteryDistanceAccumulated"]["value"]
+                if (
                     "xevBatteryTemperature" in self.data and self.data["xevBatteryTemperature"] is not None and self.data["xevBatteryTemperature"]["value"] is not None
                 ):
                     cs["Battery Temperature"] = self.data["xevBatteryTemperature"]["value"]
@@ -478,7 +509,7 @@ class CarSensor(
                     cs["Charging Amperage"] = float(self.data["xevBatteryChargerCurrentOutput"]["value"])
                     chAmps = cs["Charging Amperage"]
                 if (
-                    "xevBatteryChargerCurrentOutput" in self.data and self.data["xevBatteryChargerCurrentOutput"]["value"] is not None and self.data["xevBatteryChargerVoltageOutput"]["value"] is not None
+                    self.data["xevBatteryChargerCurrentOutput"]["value"] is not None and self.data["xevBatteryChargerVoltageOutput"]["value"] is not None
                 ):
                     cs["Charging kW"] =  round((chVolt * chAmps) / 1000, 2)
             
@@ -565,7 +596,9 @@ class CarSensor(
                 if "brakeTorque" in self.data:
                     attribs["brakeTorque"] = self.data["brakeTorque"]["value"]
                 if "engineSpeed" in self.data:
-                    attribs["engineSpeed"] = self.data["engineSpeed"]["value"]
+                    # Do not display for EV
+                    if "xevBatteryVoltage" not in self.data:
+                        attribs["engineSpeed"] = self.data["engineSpeed"]["value"]
                 if "gearLeverPosition" in self.data:
                     attribs["gearLeverPosition"] = self.data["gearLeverPosition"]["value"]
                 if "parkingBrakeStatus" in self.data:
@@ -576,6 +609,10 @@ class CarSensor(
                     if "xevBatteryVoltage" not in self.data:
                         # Do not display tripFuelEconomy if EV
                         attribs["tripFuelEconomy"] = self.data["tripFuelEconomy"]["value"]
+                if "xevBatteryVoltage" in self.data:
+                    # Do not display tripFuelEconomy if EV
+                    attribs["tripFuelEconomy"] = self.data["tripFuelEconomy"]["value"]
+                        
                 return attribs
             if self.sensor == "indicators":
                 alerts = {}

--- a/custom_components/fordpass/sensor.py
+++ b/custom_components/fordpass/sensor.py
@@ -215,10 +215,16 @@ class CarSensor(
                             alerts +=1
                 return alerts
             if self.sensor == "coolantTemp":
+                if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
+                    return round(float(self.data["engineCoolantTemp"]["value"] * 9/5) + 32)
                 return self.data["engineCoolantTemp"]["value"]
             if self.sensor == "outsideTemp":
+                if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
+                    return round(float(self.data["outsideTemperature"]["value"] * 9/5) + 32)
                 return self.data["outsideTemperature"]["value"]
             if self.sensor == "engineOilTemp":
+                if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
+                    return round(float(self.data["engineOilTemp"]["value"] * 9/5) + 32)
                 return self.data["engineOilTemp"]["value"]
             return None
         if ftype == "measurement":
@@ -233,9 +239,13 @@ class CarSensor(
             if self.sensor == "oil":
                 return "%"
             if self.sensor == "coolantTemp":
+                if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
+                    return "°F"
                 return "°C"
             if self.sensor == "outsideTemp":
-                return "°C"            
+                if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
+                    return "°F"
+                return "°C"
             if self.sensor == "tirePressure":
                 return None
             if self.sensor == "gps":
@@ -275,8 +285,10 @@ class CarSensor(
             if self.sensor == "odometer":
                 return self.data[self.sensor].items()
             if self.sensor == "outsideTemp":
-                if "ambientTemp" in self.data:
-                    return self.data["ambientTemp"]["value"]                
+                if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
+                    return round(float(self.data["ambientTemp"]["value"] * 9/5) + 32)
+                return self.data["ambientTemp"]["value"]   
+
             if self.sensor == "fuel":
                 if "fuelRange" in self.data:
                     if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
@@ -497,7 +509,10 @@ class CarSensor(
                 if (
                     "xevBatteryTemperature" in self.data and self.data["xevBatteryTemperature"] is not None and self.data["xevBatteryTemperature"]["value"] is not None
                 ):
-                    cs["Battery Temperature"] = self.data["xevBatteryTemperature"]["value"]
+                    if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
+                        cs["Battery Temperature"] = round(float(self.data["xevBatteryTemperature"]["value"] * 9/5) + 32)
+                    else: 
+                        cs["Battery Temperature"] = self.data["xevBatteryTemperature"]["value"]
                 if (
                     "xevBatteryChargerVoltageOutput" in self.data and self.data["xevBatteryChargerVoltageOutput"] is not None and self.data["xevBatteryChargerVoltageOutput"]["value"] is not None
                 ):
@@ -596,8 +611,8 @@ class CarSensor(
                 if "brakeTorque" in self.data:
                     attribs["brakeTorque"] = self.data["brakeTorque"]["value"]
                 if "engineSpeed" in self.data:
-                    # Do not display for EV
                     if "xevBatteryVoltage" not in self.data:
+                        # Do not display for EV
                         attribs["engineSpeed"] = self.data["engineSpeed"]["value"]
                 if "gearLeverPosition" in self.data:
                     attribs["gearLeverPosition"] = self.data["gearLeverPosition"]["value"]

--- a/custom_components/fordpass/sensor.py
+++ b/custom_components/fordpass/sensor.py
@@ -441,6 +441,7 @@ class CarSensor(
                     battAmps = elecs["Battery Amperage"]
                 if (
                     "xevBatteryIoCurrent" in self.data and self.data["xevBatteryIoCurrent"] is not None and self.data["xevBatteryIoCurrent"]["value"] is not None
+                    and "xevBatteryVoltage" in self.data and self.data["xevBatteryVoltage"] is not None and self.data["xevBatteryVoltage"]["value"] is not None
                 ):
                     elecs["Battery kW"] =  round((battVolt * battAmps) / 1000, 2)
                     
@@ -455,7 +456,8 @@ class CarSensor(
                     elecs["Motor Amperage"] = float(self.data["xevTractionMotorCurrent"]["value"])
                     motorAmps = elecs["Motor Amperage"]
                 if (
-                    "xevTractionMotorVoltage" in self.data and self.data["xevTractionMotorVoltage"] is not None and self.data["xevTractionMotorVoltage"]["value"] is not None 
+                    "xevTractionMotorVoltage" in self.data and self.data["xevTractionMotorVoltage"] is not None and self.data["xevTractionMotorVoltage"]["value"] is not None
+                    and "xevTractionMotorCurrent" in self.data and self.data["xevTractionMotorCurrent"] is not None and self.data["xevTractionMotorCurrent"]["value"] is not None
                 ):
                     elecs["Motor kW"] =  round((motorVolt * motorAmps) / 1000, 2)
                         
@@ -516,6 +518,7 @@ class CarSensor(
                     chAmps = cs["Charging Amperage"]
                 if (
                     self.data["xevBatteryChargerCurrentOutput"]["value"] is not None and self.data["xevBatteryChargerVoltageOutput"]["value"] is not None
+                    and "xevBatteryChargerVoltageOutput" in self.data and self.data["xevBatteryChargerVoltageOutput"] is not None and self.data["xevBatteryChargerVoltageOutput"]["value"] is not None
                 ):
                     cs["Charging kW"] =  round((chVolt * chAmps) / 1000, 2)
             
@@ -615,10 +618,10 @@ class CarSensor(
                 if "tripFuelEconomy" in self.data:
                     if "xevBatteryVoltage" not in self.data:
                         # Do not display tripFuelEconomy if EV
+                        if "xevBatteryRange" in self.data:
+                        # DO display for Hybrid
+                            attribs["tripFuelEconomy"] = self.data["tripFuelEconomy"]["value"]
                         attribs["tripFuelEconomy"] = self.data["tripFuelEconomy"]["value"]
-                if "xevBatteryVoltage" in self.data:
-                    # Do not display tripFuelEconomy if EV
-                    attribs["tripFuelEconomy"] = self.data["tripFuelEconomy"]["value"]
                         
                 return attribs
             if self.sensor == "indicators":


### PR DESCRIPTION
Added nearly every EV key I could find.
Removed a few duplicates from elVeh that because duplicate when I created elVehCharging

Added a check to engineSpeed that disabled the attribute if json reports back an EV key

Added ambientTemp under outsideTemp for an attribute

Added tripFuelEconomy under speed

Temperature conversions rely upon the user key for mi/km
if miles, it converts to F

![image](https://github.com/itchannel/fordpass-ha/assets/145411069/5d3b0017-6683-4c99-b9da-af2cf127c874)
![image](https://github.com/itchannel/fordpass-ha/assets/145411069/62d4b8e6-f2fe-4041-b587-f5bd7b85d34a)

