### PR TITLE
Fix ignition switch status during remote start

### DIFF
--- a/custom_components/fordpass/switch.py
+++ b/custom_components/fordpass/switch.py
@@ -82,12 +82,25 @@ class Switch(FordPassEntity, SwitchEntity):
     def is_on(self):
         """Check status of switch"""
         if self.switch == "ignition":
+            # Return None if both ignitionStatus and remoteStartCountdownTimer are None
             if (
-                self.coordinator.data["metrics"] is None or self.coordinator.data["metrics"]["ignitionStatus"] is None
+                self.coordinator.data["metrics"] is None 
+                or (
+                    self.coordinator.data["metrics"]["ignitionStatus"] is None 
+                    and self.coordinator.data["metrics"]["remoteStartCountdownTimer"] is None
+                )
             ):
                 return None
-            if self.coordinator.data["metrics"]["ignitionStatus"]["value"] == "OFF":
-                return False
+
+            # First check if ignitionStatus is ON
+            if self.coordinator.data["metrics"]["ignitionStatus"] is not None:
+                if self.coordinator.data["metrics"]["ignitionStatus"]["value"] == "ON":
+                    return True
+                
+            # Then check if remoteStartCountdownTimer is greater than 0, which means a remote start is in progress
+            if self.coordinator.data["metrics"]["remoteStartCountdownTimer"] is not None:
+                if self.coordinator.data["metrics"]["remoteStartCountdownTimer"]["value"] > 0:
+                    return True
         if self.switch == "guardmode":
             # Need to find the correct response for enabled vs disabled so this may be spotty at the moment
             guardstatus = self.coordinator.data["guardstatus"]


### PR DESCRIPTION
I noticed in my case that ignitionStatus does not change state during remote start, only when I'm actually driving.

Changed the is_on of the ignition switch to return true during remote start.