### PR TITLE
Doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We want to keep you informed about the latest developments regarding the integra
 
 - **Ongoing Work:** We both want to continue enhancing the integration and ensuring its functionality. However, it's important to note that we have limited time to allocate to this effort.
 
-- **Future Updates:** We are continuing our efforts to adapt to new changes and persure further enhancments.
+- **Future Updates:** We are continuing our efforts to adapt to new changes and persue further enhancments.
 
 
 #### Please understand that there may be issues, or disruptions, to different sensors during this process.
@@ -30,6 +30,7 @@ We want to keep you informed about the latest developments regarding the integra
 If you have any questions or concerns, please either open a new issue or comment on an existing issue related to yours.
 
 Thank you,
+
 itchannel and SquidBytes
 
 ## Credit 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,34 @@
 
 [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/itchannel)
 
+# Important Update: New Ford API Challenges and Updates
+
+Dear FordPass Integration Users,
+
+We want to keep you informed about the latest developments regarding the integration. Ford has recently introduced a new API, which has presented both opportunities and challenges. Here are some key points to note:
+
+## Challenges and Issues:
+
+- **Increased Complexity:** The new API has brought about several challenges and complexities. While it has enabled new attributes and sensors for different vehicles, it has also made integration more intricate.
+
+- **Vehicle Variety:** In addition to an entirely new data structure, it is difficult to determine the variety of vehicles that can be supported - without knowing their capabilities. We are assessing which vehicles contain the information necessary to enable different sensors.
+
+- **Unstable Nature of the New API:** Currently, the API appears to be unstable and/or changing. Any changes to its structure can disrupt sensor data. It is difficult to determine why: vehicles may still be in the process of migration, needing an update, or have a different data structure. Either way, instability has been noticed, and any updates or changes to the API can impact this integration.
+
+## Ongoing Work and Future Updates:
+
+- **Ongoing Work:** We both want to continue enhancing the integration and ensuring its functionality. However, it's important to note that we have limited time to allocate to this effort.
+
+- **Future Updates:** We are continuing our efforts to adapt to new changes and persure further enhancments.
+
+
+#### Please understand that there may be issues, or disruptions, to different sensors during this process.
+
+If you have any questions or concerns, please either open a new issue or comment on an existing issue related to yours.
+
+Thank you,
+itchannel and SquidBytes
+
 ## Credit 
 - https://github.com/clarkd - Initial Home Assistant automation idea and Python code (Lock/Unlock)
 - https://github.com/pinballnewf - Figuring out the application ID issue
@@ -11,6 +39,7 @@
 - https://github.com/tonesto7 - Extra window statuses and sensors
 - https://github.com/JacobWasFramed - Updated unit conversions
 - https://github.com/heehoo59 - French Translation
+- https://github.com/SquidBytes - EV updates and documentation
 
 ## Account Warning (Sep 2023)
 A number of users have encountered their accounts being banned for containing "+" symbols in their email. It appears Ford thinks this is a disposable email. So if you have a + in your email I recommend changing it.

--- a/README.md
+++ b/README.md
@@ -45,12 +45,8 @@ itchannel and SquidBytes
 ## Account Warning (Sep 2023)
 A number of users have encountered their accounts being banned for containing "+" symbols in their email. It appears Ford thinks this is a disposable email. So if you have a + in your email I recommend changing it.
 
-## 1.50 Change
-As of 1.50 VIN number is no longer required for setup. Integration should display a list of vehicles associated with your Fordpass account
-
-## 1.47 Change
-If you are experiencing issues with the odometer displaying wrong, please try enabling the checkbox in options for "Disable Distance Conversion"
-
+## **Changelog**
+[Updates](info.md)
 
 ## Install
 Use HACS and add as a custom repo. Once the integration is installed go to your integrations and follow the configuration options to specify the below:

--- a/custom_components/fordpass/sensor.py
+++ b/custom_components/fordpass/sensor.py
@@ -211,16 +211,10 @@ class CarSensor(
                             alerts +=1
                 return alerts
             if self.sensor == "coolantTemp":
-                if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
-                    return round(float(self.data["engineCoolantTemp"]["value"] * 9/5) + 32)
                 return self.data["engineCoolantTemp"]["value"]
             if self.sensor == "outsideTemp":
-                if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
-                    return round(float(self.data["outsideTemperature"]["value"] * 9/5) + 32)
                 return self.data["outsideTemperature"]["value"]
             if self.sensor == "engineOilTemp":
-                if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
-                    return round(float(self.data["engineOilTemp"]["value"] * 9/5) + 32)
                 return self.data["engineOilTemp"]["value"]
             return None
         if ftype == "measurement":
@@ -278,9 +272,8 @@ class CarSensor(
             if self.sensor == "odometer":
                 return self.data[self.sensor].items()
             if self.sensor == "outsideTemp":
-                if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":
-                    return {"Ambient Temp": round(float(self.data["ambientTemp"]["value"] * 9/5) + 32)}
-                return {"Ambient Temp": self.data["ambientTemp"]["value"]}
+                if "ambientTemp" in self.data:
+                    return {"Ambient Temp": self.data["ambientTemp"]["value"]}
             if self.sensor == "fuel":
                 if "fuelRange" in self.data:
                     if self.fordoptions[CONF_DISTANCE_UNIT] == "mi":

--- a/custom_components/fordpass/sensor.py
+++ b/custom_components/fordpass/sensor.py
@@ -350,10 +350,6 @@ class CarSensor(
                             doors[value['vehicleSide']] = value['value']
                         else:
                             doors[value['vehicleDoor']] = value['value']
-                    elif value['vehicleDoor'] == "INNER_TAILGATE":
-                        if "xevBatteryCapacity" in self.data:
-                            value['vehicleDoor'] = "FRUNK" 
-                            doors[value['vehicleDoor']] = value['value']
                     else:
                         doors[value["vehicleDoor"]] = value['value']
                 if "hoodStatus" in self.data:


### PR DESCRIPTION
Added the important update to the README.
Removed the changes / version info from the README, and instead linked to info.md

Moving forward I think the Installation, refresh and token things might be able to be moved to the Wiki and be updated / maintained there for easy changes.

I verified that the INNER_TAILGATE on EV's is not the Frunk. It still reports under Hood - so I removed that section I previously added. I have no idea what INNER_TAILGATE is.

I also removed code conversions for items that are now using HA conversions. I think the ambientTemp attribute I added under outsideTemp broke and caused #370.
I added a check for ambientTemp, and return it

I also removed the in code conversions for
engineCoolantTemp
outsideTemperature
engineOilTemp

As they were probably doing extra conversions because my outside temp is reporting as 156 F.
In my dev env (with this code in the PR) this is reporting accurately.