### PR TITLE
Fix token generation due to locale variables

### DIFF
--- a/custom_components/fordpass/config_flow.py
+++ b/custom_components/fordpass/config_flow.py
@@ -213,7 +213,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         code_verifier = self.generate_hash(code1)
         self.login_input["code_verifier"] = code1
         
-        url = f"https://login.ford.com/4566605f-43a7-400a-946e-89cc9fdb0bd7/B2C_1A_SignInSignUp_{REGIONS[region]["locale"]}/oauth2/v2.0/authorize?redirect_uri=fordapp://userauthorized&response_type=code&max_age=3600&code_challenge={code_verifier}&code_challenge_method=S256&scope=%2009852200-05fd-41f6-8c21-d36d3497dc64%20openid&client_id=09852200-05fd-41f6-8c21-d36d3497dc64&ui_locales={REGIONS[region]["locale"]}&language_code={REGIONS[region]["locale"]}&country_code={REGIONS[region]["locale_short"]}&ford_application_id={REGIONS[region]["region"]}"
+        url = f"{REGIONS[region]["locale_url"]}/4566605f-43a7-400a-946e-89cc9fdb0bd7/B2C_1A_SignInSignUp_{REGIONS[region]["locale"]}/oauth2/v2.0/authorize?redirect_uri=fordapp://userauthorized&response_type=code&max_age=3600&code_challenge={code_verifier}&code_challenge_method=S256&scope=%2009852200-05fd-41f6-8c21-d36d3497dc64%20openid&client_id=09852200-05fd-41f6-8c21-d36d3497dc64&ui_locales={REGIONS[region]["locale"]}&language_code={REGIONS[region]["locale"]}&country_code={REGIONS[region]["locale_short"]}&ford_application_id={REGIONS[region]["region"]}"
         
         return url
     def base64_url_encode(self, data):

--- a/custom_components/fordpass/const.py
+++ b/custom_components/fordpass/const.py
@@ -86,7 +86,7 @@ WINDOW_POSITIONS = {
 REGIONS = {
     "UK&Europe": {
         "region": "1E8C7794-FF5F-49BC-9596-A1E0C86C5B19",
-        "locale": "EN-IE",
+        "locale": "en-IE",
         "locale_short": "IE", #Temp fix 
         "locale_url": "https://login.ford.ie"
     },


### PR DESCRIPTION
Change locale for Europe to 'en-IE' instead of 'EN-IE' and use locale_url in config_flow for the token generation to avoid the blank page. Tested and working in Belgium.