### PR TITLE
Avoid deprecated setting of config_entry

### DIFF
--- a/custom_components/fordpass/config_flow.py
+++ b/custom_components/fordpass/config_flow.py
@@ -288,7 +288,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class OptionsFlow(config_entries.OptionsFlow):
     def __init__(self, config_entry: config_entries.ConfigEntry):
         """Initialize options flow."""
-        self.config_entry = config_entry
+        self._config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         if user_input is not None:
@@ -296,25 +296,25 @@ class OptionsFlow(config_entries.OptionsFlow):
         options = {
             vol.Optional(
                 CONF_PRESSURE_UNIT,
-                default=self.config_entry.options.get(
+                default=self._config_entry.options.get(
                     CONF_PRESSURE_UNIT, DEFAULT_PRESSURE_UNIT
                 ),
             ): vol.In(PRESSURE_UNITS),
             vol.Optional(
                 CONF_DISTANCE_UNIT,
-                default=self.config_entry.options.get(
+                default=self._config_entry.options.get(
                     CONF_DISTANCE_UNIT, DEFAULT_DISTANCE_UNIT
                 ),
             ): vol.In(DISTANCE_UNITS),
             vol.Optional(
                 DISTANCE_CONVERSION_DISABLED,
-                default=self.config_entry.options.get(
+                default=self._config_entry.options.get(
                     DISTANCE_CONVERSION_DISABLED, DISTANCE_CONVERSION_DISABLED_DEFAULT
                 ),
             ): bool,
             vol.Optional(
                 UPDATE_INTERVAL,
-                default=self.config_entry.options.get(
+                default=self._config_entry.options.get(
                     UPDATE_INTERVAL, UPDATE_INTERVAL_DEFAULT
                 ),
             ): int,


### PR DESCRIPTION
According to https://developers.home-assistant.io/blog/2024/11/12/options-flow?_highlight=config_entry#backwards-compatibility the components should no longer set the config_entry directly. Currently it results in a warning in HA:

```
Logger: homeassistant.helpers.frame
Quelle: helpers/frame.py:324
Erstmals aufgetreten: 10:07:21 (1 Vorkommnisse)
Zuletzt protokolliert: 10:07:21

Detected that custom integration 'fordpass' sets option flow config_entry explicitly, which is deprecated at custom_components/fordpass/config_flow.py, line 291: self.config_entry = config_entry. This will stop working in Home Assistant 2025.12, please create a bug report at https://github.com/itchannel/fordpass-ha/issues
```