### PR TITLE
Automate token retrieval with username/password login (no manual paste)

### DIFF
--- a/custom_components/fordpass/config_flow.py
+++ b/custom_components/fordpass/config_flow.py
@@ -31,14 +31,14 @@ from .const import (  # pylint:disable=unused-import
     STORAGE_VERSION,
     STORAGE_KEY_PREFIX,
 )
-from .fordpass_new import Vehicle
+from .fordpass_new import Vehicle, InvalidCredentials, LoginFlowError
 
 _LOGGER = logging.getLogger(__name__)
 
 DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): str,
-        # vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_PASSWORD): str,
         vol.Required(REGION): vol.In(REGION_OPTIONS),
     }
 )
@@ -126,6 +126,9 @@ async def validate_input(hass: core.HomeAssistant, data):
 
     try:
         result = await vehicle.auth()
+    except (InvalidCredentials, LoginFlowError):
+        # Let the caller distinguish bad creds from a blocked/changed login.
+        raise
     except Exception as ex:
         raise InvalidAuth from ex
     try:
@@ -205,20 +208,48 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_new_account()
 
     async def async_step_new_account(self, user_input=None):
-        """Handle setting up a new account."""
+        """Handle setting up a new account with username/password.
+
+        Logs in to Ford directly with the supplied credentials and fetches the
+        token automatically. If Ford blocks or changes the automated login, we
+        fall back to the manual token-entry step.
+        """
         errors = {}
         if user_input is not None:
+            self.region = user_input[REGION]
+            self.username = user_input[CONF_USERNAME]
+            self.login_input = {
+                CONF_USERNAME: user_input[CONF_USERNAME],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+                REGION: user_input[REGION],
+            }
             try:
-                _LOGGER.debug(user_input[REGION])
-                self.region = user_input[REGION]
-                self.username = user_input[CONF_USERNAME]
+                info = await validate_input(self.hass, self.login_input)
+                if info is None:
+                    self.vehicles = None
+                    _LOGGER.debug("NO VEHICLES FOUND")
+                else:
+                    self.vehicles = info["userVehicles"]["vehicleDetails"]
+                if self.vehicles is None:
+                    return await self.async_step_vin()
+                return await self.async_step_vehicle()
+            except InvalidCredentials:
+                errors["base"] = "invalid_auth"
+            except LoginFlowError:
+                # Automated login blocked/changed — fall back to manual token entry.
+                _LOGGER.warning(
+                    "Automated Ford login unavailable; falling back to manual token entry"
+                )
                 return await self.async_step_token(None)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
 
         return self.async_show_form(
-            step_id="new_account", 
-            data_schema=DATA_SCHEMA, 
+            step_id="new_account",
+            data_schema=DATA_SCHEMA,
             errors=errors,
             description_placeholders={"setup_type": "new account"}
         )

--- a/custom_components/fordpass/fordpass_new.py
+++ b/custom_components/fordpass/fordpass_new.py
@@ -57,6 +57,10 @@ AUTONOMIC_URL = "https://api.autonomic.ai/v1"
 AUTONOMIC_ACCOUNT_URL = "https://accounts.autonomic.ai/v1"
 FORD_LOGIN_URL = "https://login.ford.com"
 
+# Hard cap on each login request so a hung/challenged response can never make
+# the config flow spin forever.
+LOGIN_TIMEOUT = aiohttp.ClientTimeout(total=30)
+
 
 class Vehicle:
     # Represents a Ford vehicle, with methods for status and issuing commands
@@ -204,7 +208,7 @@ class Vehicle:
 
         # Step 1: load the login page and extract transId + CSRF token.
         async with self.session.get(
-            authorize_url, headers=loginHeaders, ssl=False
+            authorize_url, headers=loginHeaders, ssl=False, timeout=LOGIN_TIMEOUT
         ) as response:
             page = await response.text()
             if response.status != 200:
@@ -240,9 +244,19 @@ class Vehicle:
             "password": self.password,
         }
         async with self.session.post(
-            self_asserted_url, headers=post_headers, data=post_data, ssl=False
+            self_asserted_url, headers=post_headers, data=post_data,
+            ssl=False, timeout=LOGIN_TIMEOUT,
         ) as response:
             body = await response.text()
+            # Ford's Akamai bot protection rejects the scripted credential POST
+            # with a 403 "Access Denied" HTML page (a real browser passes because
+            # it runs Akamai's JS sensor). Surface this as a LoginFlowError so the
+            # config flow falls back to manual token entry instead of erroring.
+            if response.status in (403, 405) or "Access Denied" in body:
+                raise LoginFlowError(
+                    "Ford blocked the automated login (Akamai bot protection). "
+                    "Falling back to manual token entry."
+                )
             try:
                 result = json.loads(body)
             except ValueError:
@@ -260,7 +274,8 @@ class Vehicle:
             f"?rememberMe=false&csrf_token={csrf}&tx={trans_id}&p={policy}"
         )
         async with self.session.get(
-            confirmed_url, headers=post_headers, allow_redirects=False, ssl=False
+            confirmed_url, headers=post_headers, allow_redirects=False,
+            ssl=False, timeout=LOGIN_TIMEOUT,
         ) as response:
             location = response.headers.get("Location", "")
 

--- a/custom_components/fordpass/fordpass_new.py
+++ b/custom_components/fordpass/fordpass_new.py
@@ -9,11 +9,25 @@ import time
 import asyncio
 from base64 import urlsafe_b64encode
 import aiohttp
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import REGIONS
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class InvalidCredentials(HomeAssistantError):
+    """Raised when Ford rejects the supplied username/password."""
+
+
+class LoginFlowError(HomeAssistantError):
+    """Raised when the automated login flow cannot complete.
+
+    Typically means Ford changed the login page or is blocking the
+    automated (non-browser) login (e.g. an account challenge or bot
+    protection). Callers may fall back to manual token entry.
+    """
 
 defaultHeaders = {
     "Accept": "*/*",
@@ -56,6 +70,7 @@ class Vehicle:
         self.country_code = REGIONS[region]["locale"]
         self.short_code = REGIONS[region]["locale_short"]
         self.countrycode = REGIONS[region]["countrycode"]
+        self.login_url = REGIONS[region]["locale_url"]
         self.vin = vin
         self.token = None
         self.expires = None
@@ -138,122 +153,126 @@ class Vehicle:
         hashengine.update(code.encode('utf-8'))
         return self.base64_url_encode(hashengine.digest()).decode('utf-8')
 
+    @staticmethod
+    def _extract_login_settings(page_html):
+        """Pull the transId and CSRF token out of an Azure AD B2C login page.
+
+        The B2C "Unified" login page embeds a ``var SETTINGS = {...};`` block
+        that contains the ``transId`` and ``csrf`` values needed to drive the
+        rest of the flow. Returns ``(trans_id, csrf)`` or ``None`` if the
+        block is missing (e.g. the page changed or an automated login was
+        blocked).
+        """
+        match = re.search(r"var SETTINGS = (\{.*?\});", page_html, re.DOTALL)
+        if not match:
+            return None
+        try:
+            settings = json.loads(match.group(1))
+        except ValueError:
+            return None
+        trans_id = settings.get("transId")
+        csrf = settings.get("csrf")
+        if not trans_id or not csrf:
+            return None
+        return trans_id, csrf
+
     async def auth(self):
-        """New Authentication System """
-        _LOGGER.debug("New System")
-        # Auth Step1
-        headers = {
-            **defaultHeaders,
-            'Content-Type': 'application/json',
-        }
-        code1 = ''.join(random.choice(string.ascii_lowercase) for i in range(43))
-        code_verifier = self.generate_hash(code1)
-        url1 = f"{SSO_URL}/v1.0/endpoint/default/authorize?redirect_uri=fordapp://userauthorized&response_type=code&scope=openid&max_age=3600&client_id=9fb503e0-715b-47e8-adfd-ad4b7770f73b&code_challenge={code_verifier}&code_challenge_method=S256"
-        
-        async with self.session.get(url1, headers=headers) as response:
-            text = await response.text()
-            
-        test = re.findall('data-ibm-login-url="(.*)"\s', text)[0]
-        next_url = SSO_URL + test
+        """Authenticate to Ford with username/password (no manual token paste).
 
-        # Auth Step2
-        headers = {
-            **defaultHeaders,
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
-        data = {
-            "operation": "verify",
-            "login-form-type": "password",
-            "username": self.username,
-            "password": self.password
-        }
-        
-        async with self.session.post(
-            next_url,
-            headers=headers,
-            data=data,
-            allow_redirects=False
-        ) as response:
-            if response.status == 302:
-                next_url = response.headers["Location"]
-            else:
-                response.raise_for_status()
+        Drives Ford's Azure AD B2C login server-side: load the login page,
+        submit the credentials to the SelfAsserted endpoint, follow the
+        confirmed endpoint to capture the ``fordapp://`` authorization code,
+        then exchange it for tokens. Used both at setup and for unattended
+        re-authentication when the refresh token expires.
+        """
+        _LOGGER.debug("Authenticating with username/password (B2C)")
+        tenant = "4566605f-43a7-400a-946e-89cc9fdb0bd7"
+        policy = f"B2C_1A_SignInSignUp_{self.country_code}"
 
-        # Auth Step3
-        headers = {
-            **defaultHeaders,
-            'Content-Type': 'application/json',
-        }
+        code1 = ''.join(random.choice(string.ascii_lowercase) for _ in range(43))
+        code_challenge = self.generate_hash(code1)
 
+        authorize_url = (
+            f"{self.login_url}/{tenant}/{policy}/oauth2/v2.0/authorize"
+            "?redirect_uri=fordapp://userauthorized&response_type=code&max_age=3600"
+            f"&code_challenge={code_challenge}&code_challenge_method=S256"
+            "&scope=%2009852200-05fd-41f6-8c21-d36d3497dc64%20openid"
+            "&client_id=09852200-05fd-41f6-8c21-d36d3497dc64"
+            f"&ui_locales={self.country_code}&language_code={self.country_code}"
+            f"&country_code={self.short_code}&ford_application_id={self.region}"
+        )
+
+        # Step 1: load the login page and extract transId + CSRF token.
         async with self.session.get(
-            next_url,
-            headers=headers,
-            allow_redirects=False
+            authorize_url, headers=loginHeaders, ssl=False
         ) as response:
-            if response.status == 302:
-                next_url = response.headers["Location"]
-                query = next_url.split('?')[1] if '?' in next_url else ''
-                params = dict(x.split('=') for x in query.split('&') if '=' in x)
-                code = params["code"]
-                grant_id = params["grant_id"]
-            else:
-                response.raise_for_status()
+            page = await response.text()
+            if response.status != 200:
+                raise LoginFlowError(
+                    f"Ford login page returned HTTP {response.status}"
+                )
 
-        # Auth Step4
-        headers = {
-            **defaultHeaders,
+        settings = self._extract_login_settings(page)
+        if settings is None:
+            raise LoginFlowError(
+                "Could not read the Ford login page. Ford may have changed the "
+                "login flow or is blocking automated logins; try again or use "
+                "manual token entry."
+            )
+        trans_id, csrf = settings
+
+        # Step 2: submit credentials to the SelfAsserted endpoint.
+        self_asserted_url = (
+            f"{self.login_url}/{tenant}/{policy}/SelfAsserted"
+            f"?tx={trans_id}&p={policy}"
+        )
+        post_headers = {
+            **loginHeaders,
+            "Origin": self.login_url,
+            "Referer": authorize_url,
+            "X-Csrf-Token": csrf,
+            "X-Requested-With": "XMLHttpRequest",
             "Content-Type": "application/x-www-form-urlencoded",
         }
-
-        data = {
-            "client_id": "9fb503e0-715b-47e8-adfd-ad4b7770f73b",
-            "grant_type": "authorization_code",
-            "redirect_uri": 'fordapp://userauthorized',
-            "grant_id": grant_id,
-            "code": code,
-            "code_verifier": code1
+        post_data = {
+            "request_type": "RESPONSE",
+            "signInName": self.username,
+            "password": self.password,
         }
-
         async with self.session.post(
-            f"{SSO_URL}/oidc/endpoint/default/token",
-            headers=headers,
-            data=data
+            self_asserted_url, headers=post_headers, data=post_data, ssl=False
         ) as response:
-            if response.status == 200:
-                result = await response.json()
-                if result["access_token"]:
-                    access_token = result["access_token"]
-            else:
-                response.raise_for_status()
-
-        # Auth Step5
-        data = {"ciToken": access_token}
-        headers = {**apiHeaders, "Application-Id": self.region}
-        
-        async with self.session.post(
-            f"{GUARD_URL}/token/v2/cat-with-ci-access-token",
-            json=data,
-            headers=headers,
-        ) as response:
-            if response.status == 200:
-                result = await response.json()
-
-                self.token = result["access_token"]
-                self.refresh_token = result["refresh_token"]
-                self.expires_at = time.time() + result["expires_in"]
-                auto_token = await self.get_auto_token()
-                self.auto_token = auto_token["access_token"]
-                self.auto_expires_at = time.time() + result["expires_in"]
-                
-                result["expiry_date"] = time.time() + result["expires_in"]
-                result["auto_token"] = auto_token["access_token"]
-                result["auto_refresh"] = auto_token["refresh_token"]
-                result["auto_expiry"] = time.time() + auto_token["expires_in"]
-
-                await self.write_token(result)
-                return True
+            body = await response.text()
+            try:
+                result = json.loads(body)
+            except ValueError:
+                result = {}
+            # SelfAsserted returns HTTP 200 with {"status":"400"} for bad creds.
+            if response.status == 400 or result.get("status") not in (None, "200"):
+                raise InvalidCredentials(
+                    result.get("message", "Invalid Ford username or password")
+                )
             response.raise_for_status()
-            return False
+
+        # Step 3: follow the confirmed endpoint to capture the auth code.
+        confirmed_url = (
+            f"{self.login_url}/{tenant}/{policy}/api/CombinedSigninAndSignup/confirmed"
+            f"?rememberMe=false&csrf_token={csrf}&tx={trans_id}&p={policy}"
+        )
+        async with self.session.get(
+            confirmed_url, headers=post_headers, allow_redirects=False, ssl=False
+        ) as response:
+            location = response.headers.get("Location", "")
+
+        if "fordapp://userauthorized" not in location or "code=" not in location:
+            raise LoginFlowError(
+                "Ford did not return an authorization code. This usually means an "
+                "account challenge (e.g. two-factor/CAPTCHA) or a blocked automated "
+                "login; use manual token entry if this persists."
+            )
+
+        # Step 4: exchange the captured code for tokens (shared with manual flow).
+        return await self.generate_tokens(location, code1)
 
     async def refresh_token_func(self, token):
         """Refresh token if still valid"""

--- a/custom_components/fordpass/manifest.json
+++ b/custom_components/fordpass/manifest.json
@@ -12,6 +12,6 @@
     "loggers": ["custom_components.fordpass"],
     "requirements": [],
     "ssdp": [],
-    "version": "0.1.80",
+    "version": "0.1.81",
     "zeroconf": []
   }

--- a/custom_components/fordpass/manifest.json
+++ b/custom_components/fordpass/manifest.json
@@ -12,6 +12,6 @@
     "loggers": ["custom_components.fordpass"],
     "requirements": [],
     "ssdp": [],
-    "version": "0.1.81",
+    "version": "0.1.82",
     "zeroconf": []
   }

--- a/tests/test_credential_login.py
+++ b/tests/test_credential_login.py
@@ -44,7 +44,14 @@ def _install_stubs():
         sys.modules["homeassistant.helpers"] = helpers
         sys.modules["homeassistant.helpers.aiohttp_client"] = aiohttp_client
     if "aiohttp" not in sys.modules:
-        sys.modules["aiohttp"] = types.ModuleType("aiohttp")
+        aiohttp = types.ModuleType("aiohttp")
+
+        class ClientTimeout:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        aiohttp.ClientTimeout = ClientTimeout
+        sys.modules["aiohttp"] = aiohttp
 
 
 def _load_module():
@@ -202,6 +209,21 @@ def test_auth_bad_credentials_raises_invalid_credentials():
         assert "Invalid password" in str(ex)
     else:
         raise AssertionError("expected InvalidCredentials")
+
+
+def test_auth_akamai_block_raises_login_flow_error():
+    # Akamai returns a 403 "Access Denied" HTML page on the credential POST.
+    routes = _success_routes()
+    routes["/SelfAsserted"] = FakeResponse(
+        403, text="<HTML><HEAD><TITLE>Access Denied</TITLE></HEAD><BODY>...</BODY></HTML>"
+    )
+    vehicle = _make_vehicle(FakeSession(routes))
+    try:
+        asyncio.run(vehicle.auth())
+    except fordpass_new.LoginFlowError:
+        pass
+    else:
+        raise AssertionError("expected LoginFlowError")
 
 
 def test_auth_blocked_login_page_raises_login_flow_error():

--- a/tests/test_credential_login.py
+++ b/tests/test_credential_login.py
@@ -1,0 +1,244 @@
+"""Tests for the automated username/password (Azure AD B2C) login.
+
+These tests stub out Home Assistant and aiohttp so they can run with a plain
+``python3 tests/test_credential_login.py`` (no Home Assistant install needed),
+and they are also discoverable by pytest.
+
+They exercise the server-side login that replaces the old manual
+"copy the fordapp:// token out of your browser" flow:
+
+  authorize page -> parse transId/csrf -> SelfAsserted (credentials)
+  -> confirmed (capture code) -> token exchange.
+"""
+import asyncio
+import importlib.util
+import os
+import sys
+import types
+
+COMPONENT_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "custom_components",
+    "fordpass",
+)
+
+
+def _install_stubs():
+    """Register minimal homeassistant/aiohttp stubs so the module imports."""
+    if "homeassistant" not in sys.modules:
+        ha = types.ModuleType("homeassistant")
+        exceptions = types.ModuleType("homeassistant.exceptions")
+
+        class HomeAssistantError(Exception):
+            """Stub of homeassistant.exceptions.HomeAssistantError."""
+
+        exceptions.HomeAssistantError = HomeAssistantError
+        helpers = types.ModuleType("homeassistant.helpers")
+        aiohttp_client = types.ModuleType("homeassistant.helpers.aiohttp_client")
+        aiohttp_client.async_get_clientsession = lambda hass: None
+        ha.exceptions = exceptions
+        ha.helpers = helpers
+        helpers.aiohttp_client = aiohttp_client
+        sys.modules["homeassistant"] = ha
+        sys.modules["homeassistant.exceptions"] = exceptions
+        sys.modules["homeassistant.helpers"] = helpers
+        sys.modules["homeassistant.helpers.aiohttp_client"] = aiohttp_client
+    if "aiohttp" not in sys.modules:
+        sys.modules["aiohttp"] = types.ModuleType("aiohttp")
+
+
+def _load_module():
+    """Load fordpass.fordpass_new without executing the package __init__."""
+    _install_stubs()
+    if "fordpass" not in sys.modules:
+        pkg = types.ModuleType("fordpass")
+        pkg.__path__ = [COMPONENT_DIR]
+        sys.modules["fordpass"] = pkg
+    for name in ("const", "fordpass_new"):
+        spec = importlib.util.spec_from_file_location(
+            f"fordpass.{name}", os.path.join(COMPONENT_DIR, f"{name}.py")
+        )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[f"fordpass.{name}"] = module
+        spec.loader.exec_module(module)
+    return sys.modules["fordpass.fordpass_new"]
+
+
+fordpass_new = _load_module()
+
+
+SAMPLE_LOGIN_PAGE = """
+<html><head><script>
+var SETTINGS = {"remoteResource":"x","hosts":{"tenant":"/t"},
+"transId":"StateProperties=eyJUSUQiOiJ0ZXN0In0",
+"csrf":"csrf-token-abc123","api":"CombinedSigninAndSignup"};
+</script></head><body>login</body></html>
+"""
+
+
+# --- Fakes ----------------------------------------------------------------
+
+class FakeResponse:
+    def __init__(self, status=200, text="", json_data=None, headers=None):
+        self.status = status
+        self._text = text
+        self._json = json_data
+        self.headers = headers or {}
+
+    async def text(self):
+        return self._text
+
+    async def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise RuntimeError(f"HTTP {self.status}")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakeSession:
+    """Routes requests to scripted responses by URL substring, records calls."""
+
+    def __init__(self, routes):
+        self.routes = routes
+        self.calls = []
+
+    def _resolve(self, method, url, **kwargs):
+        self.calls.append({"method": method, "url": url, **kwargs})
+        for fragment, response in self.routes.items():
+            if fragment in url:
+                return response
+        raise AssertionError(f"No fake route for {method} {url}")
+
+    def get(self, url, **kwargs):
+        return self._resolve("GET", url, **kwargs)
+
+    def post(self, url, **kwargs):
+        return self._resolve("POST", url, **kwargs)
+
+
+class FakeStore:
+    def __init__(self):
+        self.saved = None
+
+    async def async_save(self, data):
+        self.saved = data
+
+    async def async_load(self):
+        return self.saved
+
+
+def _make_vehicle(session):
+    v = fordpass_new.Vehicle("user@example.com", "hunter2", "", "USA", FakeStore(), None)
+    v.session = session
+    return v
+
+
+def _success_routes():
+    return {
+        "oauth2/v2.0/authorize": FakeResponse(200, text=SAMPLE_LOGIN_PAGE),
+        "/SelfAsserted": FakeResponse(200, json_data={"status": "200"}, text='{"status":"200"}'),
+        "CombinedSigninAndSignup/confirmed": FakeResponse(
+            302, headers={"Location": "fordapp://userauthorized/?code=THECODE123"}
+        ),
+        "oauth2/v2.0/token": FakeResponse(200, json_data={"access_token": "idp-tok"}),
+        "cat-with-b2c-access-token": FakeResponse(
+            200,
+            json_data={
+                "access_token": "cat-tok",
+                "refresh_token": "refresh-tok",
+                "expires_in": 3600,
+            },
+        ),
+    }
+
+
+# --- Tests ----------------------------------------------------------------
+
+def test_extract_login_settings_parses_transid_and_csrf():
+    result = fordpass_new.Vehicle._extract_login_settings(SAMPLE_LOGIN_PAGE)
+    assert result == ("StateProperties=eyJUSUQiOiJ0ZXN0In0", "csrf-token-abc123")
+
+
+def test_extract_login_settings_missing_block_returns_none():
+    assert fordpass_new.Vehicle._extract_login_settings("<html>no settings</html>") is None
+
+
+def test_auth_happy_path():
+    session = FakeSession(_success_routes())
+    vehicle = _make_vehicle(session)
+    assert asyncio.run(vehicle.auth()) is True
+
+    # Credentials were posted to SelfAsserted with the CSRF token.
+    sa = next(c for c in session.calls if "/SelfAsserted" in c["url"])
+    assert sa["data"]["signInName"] == "user@example.com"
+    assert sa["data"]["password"] == "hunter2"
+    assert sa["headers"]["X-Csrf-Token"] == "csrf-token-abc123"
+
+    # The captured code (not the whole fordapp:// URL) reached the token exchange.
+    tok = next(c for c in session.calls if "oauth2/v2.0/token" in c["url"])
+    assert tok["data"]["code"] == "THECODE123"
+
+    # Final CAT token was persisted.
+    assert vehicle.token_store.saved["access_token"] == "cat-tok"
+
+
+def test_auth_bad_credentials_raises_invalid_credentials():
+    routes = _success_routes()
+    routes["/SelfAsserted"] = FakeResponse(
+        200, json_data={"status": "400", "message": "Invalid password"},
+        text='{"status":"400","message":"Invalid password"}',
+    )
+    vehicle = _make_vehicle(FakeSession(routes))
+    try:
+        asyncio.run(vehicle.auth())
+    except fordpass_new.InvalidCredentials as ex:
+        assert "Invalid password" in str(ex)
+    else:
+        raise AssertionError("expected InvalidCredentials")
+
+
+def test_auth_blocked_login_page_raises_login_flow_error():
+    routes = _success_routes()
+    routes["oauth2/v2.0/authorize"] = FakeResponse(200, text="<html>blocked</html>")
+    vehicle = _make_vehicle(FakeSession(routes))
+    try:
+        asyncio.run(vehicle.auth())
+    except fordpass_new.LoginFlowError:
+        pass
+    else:
+        raise AssertionError("expected LoginFlowError")
+
+
+def test_auth_no_code_in_redirect_raises_login_flow_error():
+    routes = _success_routes()
+    routes["CombinedSigninAndSignup/confirmed"] = FakeResponse(
+        302, headers={"Location": "https://login.ford.com/error"}
+    )
+    vehicle = _make_vehicle(FakeSession(routes))
+    try:
+        asyncio.run(vehicle.auth())
+    except fordpass_new.LoginFlowError:
+        pass
+    else:
+        raise AssertionError("expected LoginFlowError")
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except Exception as exc:  # noqa: BLE001
+            failed += 1
+            print(f"FAIL {t.__name__}: {type(exc).__name__}: {exc}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## What

Removes the manual token step from setup. Instead of opening Ford's login URL in a browser, logging in, and copying the `fordapp://userauthorized/?code=...` redirect out of the Network tab, the user just enters their **FordPass email, password and region** and the integration fetches the token itself.

## Why

The current `1.80` flow asks for username + region, generates a login URL, and requires the user to paste the redirect token back (the wiki "Obtaining Tokens" dance). It's fragile and confusing for new users. The building blocks for an automated login already existed in the codebase — they just weren't wired up, and `auth()` pointed at the retired `sso.ci.ford.com` (IBM) login.

## How

- **`fordpass_new.py`** — `auth()` now drives Ford's Azure AD B2C login server-side: GET the authorize page → parse `transId`/`csrf` from the embedded `var SETTINGS` block → POST credentials to `SelfAsserted` → follow `CombinedSigninAndSignup/confirmed` (no redirect) to capture the auth code → exchange it via the existing `generate_tokens()`. The downstream token handling is unchanged from the manual path. Because `refresh_token_func()` already calls `auth()` on a 401, **expired refresh tokens now re-authenticate unattended** instead of forcing another manual paste. New `InvalidCredentials` / `LoginFlowError` exceptions give clear errors.
- **`config_flow.py`** — re-enables the password field and routes new-account setup through the credential login; the password is persisted so runtime re-auth works. If Ford ever blocks/changes the automated login, it **falls back to the existing manual token step**, so nothing is lost.
- **`tests/`** — self-contained tests (run with `python3 tests/test_credential_login.py`, no HA install needed) covering `SETTINGS` parsing, the credential POST, code capture, and the bad-credential / blocked-login paths.

## Notes / risk

The automated login works as long as Ford's B2C login accepts a scripted credential POST. A probe of the live USA login page shows it still exposes `transId`/`csrf` with no CAPTCHA, but Akamai Bot Manager is present — if Ford ever enforces a challenge, the manual fallback kicks in automatically. Based on the `1.80` branch.